### PR TITLE
Allow gamesearch to search igdb using multiple words

### DIFF
--- a/gamesearch/gamesearch.py
+++ b/gamesearch/gamesearch.py
@@ -57,7 +57,7 @@ class Gamesearch(BaseCog):
 
     @commands.command()
     @commands.bot_has_permissions(embed_links=True, add_reactions=True)
-    async def game(self, ctx, game):
+    async def game(self, ctx, *, game):
         """Search IGDB.com for games"""
 
         apikey = await self.config.apikey()


### PR DESCRIPTION
Makes gamesearch not require quotation marks around a multi-word search. Current behaviour is to silently cut off all but the first word. There might be a totally valid reason for not allowing this that I've missed, but for your other cogs, such as your imdb cog, you allow it. 