### PR TITLE
Update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,18 @@
 # Ignore cached files created by Red #
 ######################################
-*.pyc
+*.py[cod]
 tags.*
+
+# VSCode
+.vscode/*
+!.vscode/tasks.json
+!.vscode/launch.json
+*.code-workspace
+
+.history
+.ionide
+
+# Python
+.env/
+.venv/
+__pycache__/


### PR DESCRIPTION
Adds Python and VSCode stuff to gitignore, including environments and workspace configuration. The diff is pretty self-explanatory.

Edit: For the record, I license the contributions authored in this pull request under both the terms of the repository per GitHub's ToS, as well as, at your option, [`AGPL-3.0-or-later`].

[`AGPL-3.0-or-later`]: https://spdx.org/licenses/AGPL-3.0-or-later.html "GNU Affero General Public License v3.0 or later"