### PR TITLE
Include the option to get the latest xkcd

### DIFF
--- a/xkcd/__init__.py
+++ b/xkcd/__init__.py
@@ -1,6 +1,6 @@
 from .xkcd import XKCD
+from redbot.core.bot import Red
 
-
-def setup(bot):
-    n = XKCD()
+def setup(bot: Red):
+    n = XKCD(bot)
     bot.add_cog(n)

--- a/xkcd/info.json
+++ b/xkcd/info.json
@@ -1,9 +1,10 @@
 {
-  "author": ["Jintaku"],
-  "bot_version": [3,0,0],
-  "description" : "Displays xkcd entries such as description, title and image/comic from xkcd",
-  "hidden": false,
-  "install_msg" : "Share them XKCDs! Show all the comics, have fun!",
-  "short" : "Display random xkcd",
-  "tags" : ["xkcd", "comic", "jokes"]
+    "author": ["Jintaku", "nfitzen"],
+    "bot_version": [3,0,0],
+    "description": "Displays xkcd entries such as description, title and image/comic from xkcd",
+    "hidden": false,
+    "install_msg": "Share them XKCDs! Show all the comics, have fun!",
+    "short": "Display a random xkcd, or the latest one.",
+    "tags": ["xkcd", "comic", "jokes"],
+    "license": "AGPL-3.0"
 }

--- a/xkcd/info.json
+++ b/xkcd/info.json
@@ -5,6 +5,5 @@
     "hidden": false,
     "install_msg": "Share them XKCDs! Show all the comics, have fun!",
     "short": "Display a random xkcd, or the latest one.",
-    "tags": ["xkcd", "comic", "jokes"],
-    "license": "AGPL-3.0"
+    "tags": ["xkcd", "comic", "jokes"]
 }

--- a/xkcd/xkcd.py
+++ b/xkcd/xkcd.py
@@ -24,19 +24,21 @@ class XKCD(BaseCog):
             xkcd_latest = await self.get_xkcd(session=session)
             xkcd_max = xkcd_latest.get("num")
 
-            try: # weird hack.
-                if entry_number == "random" or entry_number is None:
-                    num = randint(0, xkcd_max)
-                    xkcd = await self.get_xkcd(num, session=session)
-                elif 0 < int(entry_number) <= xkcd_max:
-                    num = int(entry_number)
-                    xkcd = await self.get_xkcd(num, session=session)
-                else:
-                    num = xkcd_max
-                    xkcd = xkcd_latest
+            try:
+                entry_number = int(entry_number)
             except:
+                pass
+
+            if type(entry_number) is int:
+                assert 0 < entry_number <= xkcd_max
+                num = entry_number
+                xkcd = await self.get_xkcd(num, session=session)
+            elif entry_number == "latest":
                 num = xkcd_max
                 xkcd = xkcd_latest
+            else:
+                num = randint(0, xkcd_max)
+                xkcd = await self.get_xkcd(num, session=session)
 
         # Build Embed
         embed = discord.Embed()

--- a/xkcd/xkcd.py
+++ b/xkcd/xkcd.py
@@ -7,13 +7,12 @@ from typing import Optional, Union
 
 BaseCog = getattr(commands, "Cog", object)
 
-
 class XKCD(BaseCog):
     """Display XKCD entries"""
 
     @commands.command()
     @commands.bot_has_permissions(embed_links=True, add_reactions=True)
-    async def xkcd(self, ctx, entry_number=None):
+    async def xkcd(self, ctx, entry_number: Optional[Union[int, str]] = None):
         """Post a random xkcd. Accepts "latest" as an entry number."""
 
         # Creates random number between 0 and the latest xkcd num and queries xkcd
@@ -21,12 +20,7 @@ class XKCD(BaseCog):
             xkcd_latest = await self.get_xkcd(session=session)
             xkcd_max = xkcd_latest.get("num")
 
-            try:
-                entry_number = int(entry_number)
-            except:
-                pass
-
-            if type(entry_number) is int:
+            if isinstance(entry_number, int):
                 if not 0 < entry_number <= xkcd_max:
                     await ctx.send("Not a valid xkcd entry.")
                     return

--- a/xkcd/xkcd.py
+++ b/xkcd/xkcd.py
@@ -48,8 +48,7 @@ class XKCD(BaseCog):
         await ctx.send(embed=embed)
 
     async def get_xkcd(self, entry_number: Optional[Union[int, str]] = None, session: Optional[aiohttp.ClientSession] = None, headers: Optional[dict] = None) -> dict:
-        """Fetches the xkcd metadata for a certain entry. If unspecified, it's the latest.
-        If an error, returns None."""
+        """Fetches the xkcd metadata for a certain entry. If unspecified, it's the latest."""
         headers = {"Content-Type": "application/json"} if headers is None else headers
         current_session = aiohttp.ClientSession() if session is None else session
         try:

--- a/xkcd/xkcd.py
+++ b/xkcd/xkcd.py
@@ -14,10 +14,7 @@ class XKCD(BaseCog):
     @commands.command()
     @commands.bot_has_permissions(embed_links=True, add_reactions=True)
     async def xkcd(self, ctx, entry_number=None):
-        """Post a random xkcd. If "latest" is specified as the entry number,
-        then it selects the latest one. If "random" or no argument is
-        specified, then it selects a random one. If an invalid entry number is
-        specified, it selects the latest."""
+        """Post a random xkcd. Accepts "latest" as an entry number."""
 
         # Creates random number between 0 and the latest xkcd num and queries xkcd
         async with aiohttp.ClientSession() as session:
@@ -44,14 +41,18 @@ class XKCD(BaseCog):
 
         # Build Embed
         embed = discord.Embed()
-        embed.title = xkcd["title"] + " (" + xkcd["year"] + "/" + xkcd["month"].zfill(2) + "/" + xkcd["day"].zfill(2) + ")"
+        embed.title = (xkcd["title"] + " (" + xkcd["year"]
+                                            + "/" + xkcd["month"].zfill(2)
+                                            + "/" + xkcd["day"].zfill(2) + ")")
         embed.url = "https://xkcd.com/" + str(num) + "/"
         embed.description = xkcd["alt"]
         embed.set_image(url=xkcd["img"])
         embed.set_footer(text="Powered by xkcd")
         await ctx.send(embed=embed)
 
-    async def get_xkcd(self, entry_number: Optional[Union[int, str]] = None, session: Optional[aiohttp.ClientSession] = None, headers: Optional[dict] = None) -> dict:
+    async def get_xkcd(self, entry_number: Optional[Union[int, str]] = None,
+                       session: Optional[aiohttp.ClientSession] = None,
+                       headers: Optional[dict] = None) -> dict:
         """Fetches the xkcd metadata for a certain entry. If unspecified, it's the latest."""
         headers = {"Content-Type": "application/json"} if headers is None else headers
         current_session = aiohttp.ClientSession() if session is None else session

--- a/xkcd/xkcd.py
+++ b/xkcd/xkcd.py
@@ -3,6 +3,7 @@ from redbot.core import commands
 import aiohttp
 from numbers import Number
 from random import randint
+from typing import Optional, Union
 
 BaseCog = getattr(commands, "Cog", object)
 
@@ -12,32 +13,54 @@ class XKCD(BaseCog):
 
     @commands.command()
     @commands.bot_has_permissions(embed_links=True, add_reactions=True)
-    async def xkcd(self, ctx, *, entry_number=None):
-        """Post a random xkcd"""
+    async def xkcd(self, ctx, entry_number=None):
+        """Post a random xkcd. If "latest" is specified as the entry number,
+        then it selects the latest one. If "random" or no argument is
+        specified, then it selects a random one. If an invalid entry number is
+        specified, it selects the latest."""
 
-        # Creates random number between 0 and 2190 (number of xkcd comics at time of writing) and queries xkcd
-        headers = {"content-type": "application/json"}
-        url = "https://xkcd.com/info.0.json"
+        # Creates random number between 0 and the latest xkcd num and queries xkcd
         async with aiohttp.ClientSession() as session:
-            async with session.get(url, headers=headers) as response:
-                xkcd_latest = await response.json()
-                xkcd_max = xkcd_latest.get("num") + 1
+            xkcd_latest = await self.get_xkcd(session=session)
+            xkcd_max = xkcd_latest.get("num")
 
-        if entry_number is not None and int(entry_number) > 0 and int(entry_number) < xkcd_max:
-            i = int(entry_number)
-        else:
-            i = randint(0, xkcd_max)
-        headers = {"content-type": "application/json"}
-        url = "https://xkcd.com/" + str(i) + "/info.0.json"
-        async with aiohttp.ClientSession() as session:
-            async with session.get(url, headers=headers) as response:
-                xkcd = await response.json()
+            try: # weird hack.
+                if entry_number == "random" or entry_number is None:
+                    num = randint(0, xkcd_max)
+                    xkcd = await self.get_xkcd(num, session=session)
+                elif 0 < int(entry_number) <= xkcd_max:
+                    num = int(entry_number)
+                    xkcd = await self.get_xkcd(num, session=session)
+                else:
+                    num = xkcd_max
+                    xkcd = xkcd_latest
+            except:
+                num = xkcd_max
+                xkcd = xkcd_latest
 
         # Build Embed
         embed = discord.Embed()
-        embed.title = xkcd["title"] + " (" + xkcd["day"] + "/" + xkcd["month"] + "/" + xkcd["year"] + ")"
-        embed.url = "https://xkcd.com/" + str(i)
+        embed.title = xkcd["title"] + " (" + xkcd["year"] + "/" + xkcd["month"].zfill(2) + "/" + xkcd["day"].zfill(2) + ")"
+        embed.url = "https://xkcd.com/" + str(num) + "/"
         embed.description = xkcd["alt"]
         embed.set_image(url=xkcd["img"])
         embed.set_footer(text="Powered by xkcd")
         await ctx.send(embed=embed)
+
+    async def get_xkcd(self, entry_number: Optional[Union[int, str]] = None, session: Optional[aiohttp.ClientSession] = None, headers: Optional[dict] = None) -> dict:
+        """Fetches the xkcd metadata for a certain entry. If unspecified, it's the latest.
+        If an error, returns None."""
+        headers = {"Content-Type": "application/json"} if headers is None else headers
+        current_session = aiohttp.ClientSession() if session is None else session
+        try:
+            if entry_number is not None:
+                url = "https://xkcd.com/" + str(entry_number) + "/info.0.json"
+            else:
+                url = "https://xkcd.com/info.0.json"
+            async with current_session.get(url, headers=headers) as response:
+                    xkcd = await response.json()
+                    xkcd = xkcd.copy() # just in case.
+            return xkcd
+        finally:
+            if session is None:
+                await current_session.close()

--- a/xkcd/xkcd.py
+++ b/xkcd/xkcd.py
@@ -30,7 +30,9 @@ class XKCD(BaseCog):
                 pass
 
             if type(entry_number) is int:
-                assert 0 < entry_number <= xkcd_max
+                if not 0 < entry_number <= xkcd_max:
+                    await ctx.send("Not a valid xkcd entry.")
+                    return
                 num = entry_number
                 xkcd = await self.get_xkcd(num, session=session)
             elif entry_number == "latest":


### PR DESCRIPTION
Everything works as one would expect, but `[p]xkcd latest` will get the latest xkcd. I also cleaned up a bit of code by abstracting the xkcd query and reusing aiohttp sessions, and I changed the date format to be more universal (year-month-day is pretty widely accepted, even in the U.S.).

Edit: For the record, I license the contributions authored in this pull request under both the terms of the repository per GitHub's ToS, as well as, at your option, [`AGPL-3.0-or-later`], in hopes of an easier transition to an "or later" version for the whole project, should you wish to do so.

[`AGPL-3.0-or-later`]: https://spdx.org/licenses/AGPL-3.0-or-later.html "GNU Affero General Public License v3.0 or later"